### PR TITLE
In Progress: Update Gitignore for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ paket-files/
 *.key
 *.orig
 *.pem
+start/obj/

--- a/.gitignore
+++ b/.gitignore
@@ -256,4 +256,6 @@ paket-files/
 *.key
 *.orig
 *.pem
+
+# Workshop-specific files
 start/obj/


### PR DESCRIPTION
`/start/obj` is shown as changed in git during run.

Started this in-progress PR to ignore it.