### PR TITLE
Update README-part3.md

### DIFF
--- a/README-part3.md
+++ b/README-part3.md
@@ -4,11 +4,11 @@ Use the following docker run command, specifying a port binding for listening, t
 
 1. Go to your ASP.NET Core app's directory (or an empty directory for a new app)
 
-    `docker container run -it -p 80:80 -v $(pwd):/app -t my-app`
+    `docker container run -it -p 80:80 -v $(pwd):/app my-app`
 
     Windows:
 
-    `docker container run -it -p 80:80 -v /C/<PATH TO CLONE docker-workshop-1>/start:/app -t my-app`
+    `docker container run -it -p 80:80 -v /C/<PATH TO CLONE docker-workshop-1>/start:/app my-app`
 
     Now you can code in your host environment using your IDE as usual, and the container will receive any file changes since your application directory is mounted into the container. 
 


### PR DESCRIPTION
Extra `-t` flag isn't needed with `-it` earlier in the command line.